### PR TITLE
Memory block update

### DIFF
--- a/doc/testCode.md
+++ b/doc/testCode.md
@@ -1,6 +1,7 @@
 # Testovací kód
 ## Všechny instrukce
 
+```(asm)
 HALT
 NEGATE
 ACCDEC
@@ -20,14 +21,16 @@ BRNEG test
 MADD @0006
 IJUMP @0007
 :test
+```
 
 ## Jednoduchý program
-
-;This is simple test program
-  MLOAD 5
-loop:               ; Simple loop
-  DSTORE @10
-  ACCDEC
-  ISTORE @10
-  BRPOS loop      ; Return back
-  ; End of program
+```(asm)
+; This is simple test program
+; Fills memory 7-0 with its address value
+	MLOAD 7
+loop:
+	DSTORE @10
+	ISTORE @10
+	ACCDEC
+	BRPOS loop
+```

--- a/src/components/TheProcessor.vue
+++ b/src/components/TheProcessor.vue
@@ -102,8 +102,9 @@ export default {
                 this.Initialize();
                 this.cpu = new Cpu(this.memory, this.accumulator, this.addressPointer, this.cycleCounter);
             }
+
             this.ChangeSimulationState(s_started);
-            this.compiler.highlightLine(-1);
+            this.compiler.highlightLine(this.compiler.getNextLine(this.instructionPointer));
 
             // Program loops
             while (this.currentState == s_started) {
@@ -113,13 +114,11 @@ export default {
         },
         StopProgram() {
             console.log("Stop program");
-            this.compiler.highlightLine(-1);
             this.ChangeSimulationState(s_notStarted);
             this.Initialize();
         },
         PauseProgram() {
             console.log("Pause program");
-            this.compiler.highlightLine(this.compiler.getNextLine(this.instructionPointer));
             this.ChangeSimulationState(s_halted);
         },
         async ExecuteInstruction() {
@@ -153,11 +152,12 @@ export default {
                     console.log("Program end");
                     this.compiler.highlightLine(-1);
                     this.ChangeSimulationState(s_ended);
+                    return;
                 }
 
-                // Highlight current line if going manually
+                this.compiler.highlightLine(this.compiler.getNextLine(this.instructionPointer));
+
                 if (this.currentState == s_halted) {
-                    this.compiler.highlightLine(this.compiler.getNextLine(this.instructionPointer));
                     this.controlButtons[3].disabled = false;
                 }
             }
@@ -220,6 +220,7 @@ export default {
             this.addressPointer = { value: 0 };
             this.instruction = { instruction: "INST" };
             this.cycleCounter.value = 0;
+            this.compiler.highlightLine(-1);
             this.memory.initialize();
         }
     }

--- a/src/components/TheProcessor.vue
+++ b/src/components/TheProcessor.vue
@@ -252,7 +252,8 @@ export default {
 .program-container {
     width: 85%;
     height: 100%;
-    overflow-y: auto;
+    overflow-y: hidden;
+
     border: solid 15px var(--mainColor);
     border-left-width: 3px;
     border-right-width: 3px;

--- a/src/components/TheSettings.vue
+++ b/src/components/TheSettings.vue
@@ -1,5 +1,6 @@
 <!--
     Edit settings window
+    Source: https://vuejs.org/examples/#modal
 !-->
 
 <template>

--- a/src/components/codeEditor/CodeEditor.vue
+++ b/src/components/codeEditor/CodeEditor.vue
@@ -27,7 +27,7 @@ export default {
 
     data() {
         return {
-            code: "; This is simple test program\n; Fills memory 5-0 with its address value\n\tMLOAD 6\nloop:\n\tDSTORE @6\n\tISTORE @6\n\tACCDEC\n\tBRPOS loop\n",
+            code: "; This is simple test program\n; Fills memory 5-0 with its address value\n\tMLOAD 5\nloop:\n\tDSTORE @10\n\tISTORE @10\n\tACCDEC\n\tBRPOS loop\n",
             instructionList: [],
             labelDict: {},
             highlightedLine: -1

--- a/src/components/codeEditor/CodeEditor.vue
+++ b/src/components/codeEditor/CodeEditor.vue
@@ -27,7 +27,7 @@ export default {
 
     data() {
         return {
-            code: "",
+            code: "; This is simple test program\n; Fills memory 5-0 with its address value\n\tMLOAD 6\nloop:\n\tDSTORE @6\n\tISTORE @6\n\tACCDEC\n\tBRPOS loop\n",
             instructionList: [],
             labelDict: {},
             highlightedLine: -1

--- a/src/components/codeEditor/CodeEditor.vue
+++ b/src/components/codeEditor/CodeEditor.vue
@@ -126,15 +126,13 @@ export default {
 
 /* Word wrap line number misaling fix*/
 /* Source: https://github.com/koca/vue-prism-editor/issues/87 */
-.code-editor  .prism-editor__textarea {
+.code-editor .prism-editor__textarea {
     width: 800px !important;
 }
-.code-editor  .prism-editor__editor {
+.code-editor .prism-editor__editor {
     white-space: pre !important;
 }
-.code-editor  .prism-editor__container {
-    height: 100%;
+.code-editor .prism-editor__container {
     overflow-x: scroll !important;
 }
-
 </style>

--- a/src/components/codeEditor/CodeEditor.vue
+++ b/src/components/codeEditor/CodeEditor.vue
@@ -27,7 +27,7 @@ export default {
 
     data() {
         return {
-            code: "; This is simple test program\n; Fills memory 5-0 with its address value\n\tMLOAD 5\nloop:\n\tDSTORE @10\n\tISTORE @10\n\tACCDEC\n\tBRPOS loop\n",
+            code: "; This is simple test program\n; Fills memory 7-0 with its address value\n\tMLOAD 7\nloop:\n\tDSTORE @10\n\tISTORE @10\n\tACCDEC\n\tBRPOS loop\n",
             instructionList: [],
             labelDict: {},
             highlightedLine: -1

--- a/src/components/codeEditor/CodeEditor.vue
+++ b/src/components/codeEditor/CodeEditor.vue
@@ -111,10 +111,10 @@ export default {
     line-height: 1.5;
     padding: 5px;
 }
-.prism-editor__textarea:focus {
+.code-editor .prism-editor__textarea:focus {
     outline: none;
 }
-.prism-editor-wrapper .prism-editor__line-number.highlight-line {
+.code-editor .prism-editor__line-number.highlight-line {
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
     border-top-right-radius: 2px;
@@ -123,4 +123,18 @@ export default {
     background: var(--secondaryColor);
     color: white;
 }
+
+/* Word wrap line number misaling fix*/
+/* Source: https://github.com/koca/vue-prism-editor/issues/87 */
+.code-editor  .prism-editor__textarea {
+    width: 800px !important;
+}
+.code-editor  .prism-editor__editor {
+    white-space: pre !important;
+}
+.code-editor  .prism-editor__container {
+    height: 100%;
+    overflow-x: scroll !important;
+}
+
 </style>

--- a/src/components/codeEditor/CodeEditor.vue
+++ b/src/components/codeEditor/CodeEditor.vue
@@ -49,6 +49,7 @@ export default {
             return Prism.highlight(code, Prism.languages.bp22);
         },
         HighlightLine(lineNumber) {
+            // Source: https://github.com/evwt/vue-tut
             // Remove highlighting
             if (this.highlightedLine >= 0 )
             {
@@ -65,8 +66,7 @@ export default {
                 var newLine = this.$el.querySelector(`.prism-editor__line-number:nth-child(${lineNumber + 1})`);
                 if (!newLine) return;
                 newLine.classList.add('highlight-line');
-            }
-            
+            }       
         },
         
         CompileProgram() {

--- a/src/components/codeEditor/bp22/bp22Highlighting.js
+++ b/src/components/codeEditor/bp22/bp22Highlighting.js
@@ -1,7 +1,7 @@
 // Custom bp22 assembly language highlighting
 
 export let bp22Highlight = {
-    'operator': /\b(?:HALT|NEGATE|ACCDEC|ACCINC|NOP|OUTP|INP|MLOAD|DLOAD|ILOAD|DSTORE|ISTORE|BRANCH|BRZERO|BRPOS|BRNEG|MADD|IJUMP|LABEL)\b/i,
+    'operator': /\b(?:HALT|NEGATE|ACCDEC|ACCINC|NOP|OUTP|INP|MLOAD|DLOAD|ILOAD|DSTORE|ISTORE|BRANCH|BRZERO|BRPOS|BRNEG|MADD|IJUMP|LABEL|FLUSH)\b/i,
     'comment': /;.*/,
     'string': /@[0-9a-f]+\b/i
 };

--- a/src/components/codeEditor/bp22/bp22Highlighting.js
+++ b/src/components/codeEditor/bp22/bp22Highlighting.js
@@ -3,5 +3,5 @@
 export let bp22Highlight = {
     'operator': /\b(?:HALT|NEGATE|ACCDEC|ACCINC|NOP|OUTP|INP|MLOAD|DLOAD|ILOAD|DSTORE|ISTORE|BRANCH|BRZERO|BRPOS|BRNEG|MADD|IJUMP|LABEL)\b/i,
     'comment': /;.*/,
-    'string': /@\d*\b/
+    'string': /@[0-9a-f]+\b/i
 };

--- a/src/components/common/NumberInput.vue
+++ b/src/components/common/NumberInput.vue
@@ -1,5 +1,6 @@
 <!--
     A number input with label
+    Source: https://stackoverflow.com/questions/47311936/v-model-and-child-components
 !-->
 
 <template>

--- a/src/components/memory/DirectCacheMemory.vue
+++ b/src/components/memory/DirectCacheMemory.vue
@@ -132,7 +132,7 @@ export default {
             for (var i = 0; i < this.cacheData.length; i++) {
                 var address = this.memoryUtils.getRamAddressFromCache(this.cacheData[i].tag, i, this.cacheAddressBits - 2);
                 this.ramData[address] = [...this.cacheData[i].data];
-                this.cacheData[i].valid = true;
+                this.cacheData[i] = new CacheBlock();
             }
         },
         Initialize() {

--- a/src/components/memory/DirectCacheMemory.vue
+++ b/src/components/memory/DirectCacheMemory.vue
@@ -130,7 +130,7 @@ export default {
         },
         Flush() {
             for (var i = 0; i < this.cacheData.length; i++) {
-                var address = this.memoryUtils.getRamAddressFromCache(this.cacheData[i].tag, i, this.cacheAddressBits);
+                var address = this.memoryUtils.getRamAddressFromCache(this.cacheData[i].tag, i, this.cacheAddressBits - 2);
                 this.ramData[address] = [...this.cacheData[i].data];
                 this.cacheData[i].valid = true;
             }

--- a/src/components/memory/DirectCacheMemory.vue
+++ b/src/components/memory/DirectCacheMemory.vue
@@ -5,9 +5,9 @@
 <template>
     <processor-model :instruction="instruction" :instuctionPointer="instructionPointer"
         :accumulator="accumulator" :addressPointer="addressPointer"/>
-    <connector :id="0" :width="4" @RegisterConnector="RegisterConnector"/>
+    <connector :id="0" :width="3.5" @RegisterConnector="RegisterConnector"/>
     <cache-model :data="cacheData" :tagLength="tagLength" @SwitchValidBit="SwitchValidBit" @RegisterCache="RegisterCache"/>
-    <connector :id="1" :width="4" @RegisterConnector="RegisterConnector"/>
+    <connector :id="1" :width="3.5" @RegisterConnector="RegisterConnector"/>
     <ram-model :data="ramData" @RegisterRam="RegisterRam"/>
 </template>
 
@@ -19,6 +19,7 @@ import Connector from '../model/Connector.vue';
 
 import MemoryUtils from '@/scripts/MemoryUtils.js';
 import CacheBlock from '@/scripts/CacheBlock.js';
+import Sleep from '@/scripts/Sleep.js';
 export default {
     name: "DirectCacheMemory",
     components: { ProcessorModel, RamModel, CacheModel, Connector },
@@ -33,7 +34,16 @@ export default {
 
     computed: {
         tagLength() {
-            return Math.floor(Math.log2(this.ramData.length + 1)) - Math.floor(Math.log2(this.cacheData.length + 1));
+            return Math.floor(Math.log2(this.ramDataLength + 1)) - Math.floor(Math.log2(this.cacheDataLength + 1));
+        },
+        cacheAddressBits() {
+            return Math.floor(Math.log2(this.cacheDataLength + 1));
+        },
+        ramDataLength() {
+            return this.ramData.length * 4;
+        },
+        cacheDataLength() {
+            return this.cacheData.length * 4;
         }
     },
 
@@ -56,57 +66,63 @@ export default {
 
     methods: {
         async Write(address, data) {
-            if (address > this.ramData.length || address < 0)
-                throw RangeError(`Invalid memory address (${address}).`);
+            if (address > this.ramDataLength || address < 0)
+                throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
 
-            var cacheAddress = address & 0b11;
-            var cacheTag = (address & 0b1100) >> 2;
+            var cacheAddress = address & ((1 << this.cacheAddressBits) - 1);
+            var cacheBlock = cacheAddress >> 2;
+            var cacheTag = address >> this.cacheAddressBits;
 
             // Data koherence: valid-bit
             // Memory block is in cache
             this.cycleCounter.value += this.cycleCosts.cacheCheck;
-            if (this.cacheData[cacheAddress].tag == cacheTag) {
+            if (this.cacheData[cacheBlock].tag == cacheTag && !this.cacheData[cacheBlock].isEmpty) {
                 await this.memoryUtils.writeToCache(cacheAddress, cacheTag, data);
             }
             // Not in cache
             else {
                 // Current memory block valid - can overwrite
-                if (this.cacheData[cacheAddress].valid) {
+                if (this.cacheData[cacheBlock].valid) {
+                    await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
                     await this.memoryUtils.writeToCache(cacheAddress, cacheTag, data);
                 }
                 // Current memory block not valid - must save
                 else {
-                    var ramAddress = this.memoryUtils.getRamAddressFromCache(cacheAddress, this.cacheData[cacheAddress].tag, 2);
+                    var ramAddress = this.memoryUtils.getRamAddressFromCache(this.cacheData[cacheBlock].tag, cacheAddress, this.cacheAddressBits);
 
                     await this.memoryUtils.writeToRam(cacheAddress, ramAddress);
+                    await Sleep(this.connectorFadeTime.value / 2);
+                    await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
                     await this.memoryUtils.writeToCache(cacheAddress, cacheTag, data);
                 }
             }
         },
         async Read(address) {
-            if (address > this.ramData.length || address < 0)
-                throw RangeError(`Invalid memory address (${address}).`);
+            if (address > this.ramDataLength || address < 0)
+                throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
 
-            var cacheAddress = address & 0b11;
-            var cacheTag = (address & 0b1100) >> 2;
+            var cacheAddress = address & ((1 << this.cacheAddressBits) - 1);
+            var cacheBlock = cacheAddress >> 2;
+            var cacheTag = address >> this.cacheAddressBits;
 
             // Check in cache
             this.cycleCounter.value += this.cycleCosts.cacheCheck;
-            if (this.cacheData[cacheAddress].tag == cacheTag) {
+            if (this.cacheData[cacheBlock].tag == cacheTag && !this.cacheData[cacheBlock].isEmpty) {
                 return await this.memoryUtils.readFromCache(cacheAddress);
             }
             // Not in cache
             else {
                 // Current memory block valid - can overwrite
-                if (this.cacheData[cacheAddress].valid) {
+                if (this.cacheData[cacheBlock].valid) {
                     await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
                     return await this.memoryUtils.readFromCache(cacheAddress);
                 }
                 // Current memory block not valid - must save
                 else {
-                    var ramAddress = this.memoryUtils.getRamAddressFromCache(cacheAddress, this.cacheData[cacheAddress].tag, 2);
+                    var ramAddress = this.memoryUtils.getRamAddressFromCache(this.cacheData[cacheBlock].tag, cacheAddress, this.cacheAddressBits);
 
                     await this.memoryUtils.writeToRam(cacheAddress, ramAddress);
+                    await Sleep(this.connectorFadeTime.value / 2);
                     await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
                     return await this.memoryUtils.readFromCache(cacheAddress);
                 }
@@ -114,15 +130,15 @@ export default {
         },
         Flush() {
             for (var i = 0; i < this.cacheData.length; i++) {
-                var address = this.memoryUtils.getRamAddressFromCache(i, this.cacheData[i].tag, 2);
-                this.ramData[address] = this.cacheData[i].data;
+                var address = this.memoryUtils.getRamAddressFromCache(this.cacheData[i].tag, i, this.cacheAddressBits);
+                this.ramData[address] = [...this.cacheData[i].data];
                 this.cacheData[i].valid = true;
             }
         },
         Initialize() {
             this.ramData = Array(this.memorySize.ram);
             for (var i = 0; i < this.memorySize.ram; i++) {
-                this.ramData[i] = 0;
+                this.ramData[i] = [0, 0, 0, 0];
             }
             this.cacheData = Array(this.memorySize.cache);
             for (var j = 0; j < this.memorySize.cache; j++) {

--- a/src/components/memory/FullCacheMemory.vue
+++ b/src/components/memory/FullCacheMemory.vue
@@ -112,7 +112,7 @@ export default {
             }
         },
         async Read(address) {
-            if (address > this.ramData.length || address < 0)
+            if (address > this.ramDataLength || address < 0)
                 throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
 
             var cacheTag = address & ~(0b11);

--- a/src/components/memory/FullCacheMemory.vue
+++ b/src/components/memory/FullCacheMemory.vue
@@ -160,7 +160,7 @@ export default {
                 var address = this.cacheData[i].tag >> 2;
                 if (!this.cacheData[i].isEmpty) {
                     this.ramData[address] = [...this.cacheData[i].data];
-                    this.cacheData[i].valid = true;
+                    this.cacheData[i] = new CacheBlock();
                 }
             }
         },

--- a/src/components/memory/FullCacheMemory.vue
+++ b/src/components/memory/FullCacheMemory.vue
@@ -5,9 +5,9 @@
 <template>
     <processor-model :instruction="instruction" :instuctionPointer="instructionPointer"
         :accumulator="accumulator" :addressPointer="addressPointer"/>
-    <connector :id="0" :width="3" @RegisterConnector="RegisterConnector"/>
+    <connector :id="0" :width="3.5" @RegisterConnector="RegisterConnector"/>
     <cache-model :data="cacheData" :tagLength="tagLength" @SwitchValidBit="SwitchValidBit" @RegisterCache="RegisterCache"/>
-    <connector :id="1" :width="3" @RegisterConnector="RegisterConnector"/>
+    <connector :id="1" :width="3.5" @RegisterConnector="RegisterConnector"/>
     <ram-model :data="ramData" @RegisterRam="RegisterRam"/>
 </template>
 
@@ -19,6 +19,7 @@ import Connector from '../model/Connector.vue';
 
 import MemoryUtils from '@/scripts/MemoryUtils.js';
 import CacheBlock from '@/scripts/CacheBlock.js';
+import Sleep from '@/scripts/Sleep.js';
 export default {
     name: "FullCacheMemory",
     components: { ProcessorModel, CacheModel, RamModel, Connector },
@@ -33,7 +34,16 @@ export default {
 
     computed: {
         tagLength() {
-            return Math.floor(Math.log2(this.ramData.length + 1));
+            return Math.floor(Math.log2(this.ramDataLength + 1));
+        },
+        cacheAddressBits() {
+            return Math.floor(Math.log2(this.cacheDataLength + 1));
+        },
+        ramDataLength() {
+            return this.ramData.length * 4;
+        },
+        cacheDataLength() {
+            return this.cacheData.length * 4;
         }
     },
 
@@ -56,15 +66,17 @@ export default {
 
     methods: {
         async Write(address, data) {
-            if (address > this.ramData.length || address < 0)
-                throw RangeError(`Invalid memory address (${address}).`);
+            if (address > this.ramDataLength || address < 0)
+                throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
+
+            var cacheTag = address & ~(0b11);
 
             // Data koherence: valid-bit
             // Memory block is in cache
             for (var i = 0; i < this.cacheData.length; i++) {
                 this.cycleCounter.value += this.cycleCosts.cacheCheck;
-                if (this.cacheData[i].tag == address) {
-                    await this.memoryUtils.writeToCache(i, address, data);
+                if (this.cacheData[i].tag == cacheTag && !this.cacheData[i].isEmpty) {
+                    await this.memoryUtils.writeToCache(this.GetCacheAddress(i, address), cacheTag, data);
                     return;
                 }
             }
@@ -79,30 +91,37 @@ export default {
                 }
             }
             if (id == null) {
-                id = Math.floor(Math.random() * 4);
+                id = Math.floor(Math.random() * this.cacheData.length);
             }
+            // Shifted to keep compatibility with MemoryUtils
+            var cacheAddress = this.GetCacheAddress(id, address);
 
             // Current memory block valid - can overwrite
             if (this.cacheData[id].valid) {
-                await this.memoryUtils.writeToCache(id, address, data);
+                await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
+                await this.memoryUtils.writeToCache(cacheAddress, cacheTag, data);
             }
             // Current memory block not valid - must save
             else {
                 var ramAddress = this.cacheData[id].tag;
 
-                await this.memoryUtils.writeToRam(id, ramAddress);
-                await this.memoryUtils.writeToCache(id, address, data);
+                await this.memoryUtils.writeToRam(cacheAddress, ramAddress);
+                await Sleep(this.connectorFadeTime.value / 2);
+                await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
+                await this.memoryUtils.writeToCache(cacheAddress, cacheTag, data);
             }
         },
         async Read(address) {
             if (address > this.ramData.length || address < 0)
-                throw RangeError(`Invalid memory address (${address}).`);
+                throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
+
+            var cacheTag = address & ~(0b11);
 
             // Check in cache
             for (var i = 0; i < this.cacheData.length; i++) {
                 this.cycleCounter.value += this.cycleCosts.cacheCheck;
-                if (this.cacheData[i].tag == address) {
-                    return await this.memoryUtils.readFromCache(i);
+                if (this.cacheData[i].tag == cacheTag && !this.cacheData[i].isEmpty) {
+                    return await this.memoryUtils.readFromCache(this.GetCacheAddress(i, address));
                 }
             }
 
@@ -116,33 +135,39 @@ export default {
                 }
             }
             if (id == null) {
-                id = Math.floor(Math.random() * 4);
+                id = Math.floor(Math.random() * this.cacheData.length);
             }
+            // Shifted to keep compatibility with MemoryUtils
+            var cacheAddress = this.GetCacheAddress(id, address);
 
             // Current memory block valid - can ovewrite
             if (this.cacheData[id].valid) {
-                await this.memoryUtils.readFromRam(id, address, address);
-                return await this.memoryUtils.readFromCache(id);
+                await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
+                return await this.memoryUtils.readFromCache(cacheAddress);
             }
             // Current memory block not valid - must save
             else {
                 var ramAddress = this.cacheData[id].tag;
 
-                await this.memoryUtils.writeToRam(id, ramAddress);
-                await this.memoryUtils.readFromRam(id, address, address);
-                return await this.memoryUtils.readFromCache(id);
+                await this.memoryUtils.writeToRam(cacheAddress, ramAddress);
+                await Sleep(this.connectorFadeTime.value / 2);
+                await this.memoryUtils.readFromRam(cacheAddress, address, cacheTag);
+                return await this.memoryUtils.readFromCache(cacheAddress);
             }
         },
         Flush() {
             for (var i = 0; i < this.cacheData.length; i++) {
-                this.ramData[this.cacheData[i].tag] = this.cacheData[i].data;
-                this.cacheData[i].valid = true;
+                var address = this.cacheData[i].tag >> 2;
+                if (!this.cacheData[i].isEmpty) {
+                    this.ramData[address] = [...this.cacheData[i].data];
+                    this.cacheData[i].valid = true;
+                }
             }
         },
         Initialize() {
             this.ramData = Array(this.memorySize.ram);
             for (var i = 0; i < this.memorySize.ram; i++) {
-                this.ramData[i] = 0;
+                this.ramData[i] = [0, 0, 0, 0];
             }
             this.cacheData = Array(this.memorySize.cache);
             for (var j = 0; j < this.memorySize.cache; j++) {
@@ -153,6 +178,9 @@ export default {
 
         SwitchValidBit(row) {
             this.cacheData[row].switchValid();
+        },
+        GetCacheAddress(cache, address) {
+            return cache << 2 | address & 0b11;
         },
 
         RegisterConnector(id, connector) {

--- a/src/components/memory/RamOnlyMemory.vue
+++ b/src/components/memory/RamOnlyMemory.vue
@@ -60,7 +60,7 @@ export default {
             else throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
         },
         async Read(address) {
-            if (address < this.ramData.length && address >= 0)
+            if (address < this.ramDataLength && address >= 0)
             {
                 var block = address >> 2;
                 var offset = address & 0b11;

--- a/src/components/memory/RamOnlyMemory.vue
+++ b/src/components/memory/RamOnlyMemory.vue
@@ -34,6 +34,12 @@ export default {
         }
     },
 
+    computed: {
+        ramDataLength() {
+            return this.ramData.length * 4;
+        }
+    },
+
     created() {
         this.$emit("RegisterMemory", { write: this.Write, read: this.Read, flush: () => {}, initialize: this.Initialize });
         this.Initialize();
@@ -41,29 +47,35 @@ export default {
 
     methods: {
         async Write(address, data) {
-            if (address < this.ramData.length && address >= 0)
+            if (address < this.ramDataLength && address >= 0)
             {
+                var block = Math.floor(address / 4);
+                var offset = Math.floor(address % 4);
+
                 await this.connector.fromCpuToMemory(this.connectorFillTime.value, this.connectorFadeTime.value);
                 this.ramModel.highlight(address, this.highlightFadeTime.value);
                 this.cycleCounter.value += this.cycleCosts.ramAccess;
-                this.ramData[address] = data;
+                this.ramData[block][offset] = data;
             }
-            else throw RangeError(`Invalid memory address (${address}).`);
+            else throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
         },
         async Read(address) {
             if (address < this.ramData.length && address >= 0)
             {
+                var block = Math.floor(address / 4);
+                var offset = Math.floor(address % 4);
+
                 this.cycleCounter.value += this.cycleCosts.ramAccess;
                 this.ramModel.highlight(address, this.highlightFadeTime.value);
                 await this.connector.fromMemoryToCpu(this.connectorFillTime.value, this.connectorFadeTime.value);
-                return this.ramData[address];
+                return this.ramData[block][offset];
             }
-            else throw RangeError(`Invalid memory address (${address}).`);
+            else throw RangeError(`Invalid memory address (0x${address.toString(16).toUpperCase()}).`);
         },
         Initialize() {
             this.ramData = Array(this.memorySize.ram);
             for (var i = 0; i < this.memorySize.ram; i++) {
-                this.ramData[i] = 0;
+                this.ramData[i] = [0, 0, 0, 0];
             }
         },
 

--- a/src/components/memory/RamOnlyMemory.vue
+++ b/src/components/memory/RamOnlyMemory.vue
@@ -49,8 +49,8 @@ export default {
         async Write(address, data) {
             if (address < this.ramDataLength && address >= 0)
             {
-                var block = Math.floor(address / 4);
-                var offset = Math.floor(address % 4);
+                var block = address >> 2;
+                var offset = address & 0b11;
 
                 await this.connector.fromCpuToMemory(this.connectorFillTime.value, this.connectorFadeTime.value);
                 this.ramModel.highlight(address, this.highlightFadeTime.value);
@@ -62,8 +62,8 @@ export default {
         async Read(address) {
             if (address < this.ramData.length && address >= 0)
             {
-                var block = Math.floor(address / 4);
-                var offset = Math.floor(address % 4);
+                var block = address >> 2;
+                var offset = address & 0b11;
 
                 this.cycleCounter.value += this.cycleCosts.ramAccess;
                 this.ramModel.highlight(address, this.highlightFadeTime.value);

--- a/src/components/memory/TwoWayCacheMemory.vue
+++ b/src/components/memory/TwoWayCacheMemory.vue
@@ -171,7 +171,7 @@ export default {
                     if (!this.cacheData[i][j].isEmpty)
                     {
                         this.ramData[address] = [...this.cacheData[i][j].data];
-                        this.cacheData[i][j].valid = true;
+                        this.cacheData[i][j] = new CacheBlock();
                     }
                 }
             }

--- a/src/components/memory/TwoWayCacheMemory.vue
+++ b/src/components/memory/TwoWayCacheMemory.vue
@@ -112,7 +112,7 @@ export default {
             }
             // Current memory block not valid - must save
             else {
-                var ramAddress = this.memoryUtils.getRamAddressFromCache(cacheAddress, this.cacheData[id][cacheAddress].tag, 1);
+                var ramAddress = this.memoryUtils.getRamAddressFromCache(this.cacheData[id][cacheBlock].tag, cacheAddress, this.cacheAddressBits);
                 
                 await this.memoryUtils.writeToRam(cacheAddress, ramAddress, id);
                 await Sleep(this.connectorFadeTime.value / 2);
@@ -127,6 +127,7 @@ export default {
             var cacheAddress = address & ((1 << this.cacheAddressBits) - 1);
             var cacheBlock = cacheAddress >> 2;
             var cacheTag = address >> this.cacheAddressBits;
+            console.log(cacheAddress, cacheBlock, cacheTag);
 
             // Check in cache
             for (var i = 0; i < this.cacheData.length; i++) {
@@ -156,7 +157,7 @@ export default {
             }
             // Current memory block not valid - must save
             else {
-                var ramAddress = this.memoryUtils.getRamAddressFromCache(cacheAddress, this.cacheData[id][cacheAddress].tag, 1);
+                var ramAddress = this.memoryUtils.getRamAddressFromCache(this.cacheData[id][cacheBlock].tag, cacheAddress, this.cacheAddressBits);
                 
                 await this.memoryUtils.writeToRam(cacheAddress, ramAddress, id);
                 await Sleep(this.connectorFadeTime.value / 2);
@@ -167,7 +168,7 @@ export default {
         Flush() {
             for (var i = 0; i < this.cacheData.length; i++) {
                 for (var j = 0; j < this.cacheData[i].length; j++) {
-                    var address = this.memoryUtils.getRamAddressFromCache(this.cacheData[i][j].tag, j, 1);
+                    var address = this.memoryUtils.getRamAddressFromCache(this.cacheData[i][j].tag, j, this.cacheAddressBits - 2);
                     if (!this.cacheData[i][j].isEmpty)
                     {
                         this.ramData[address] = [...this.cacheData[i][j].data];

--- a/src/components/memory/TwoWayCacheMemory.vue
+++ b/src/components/memory/TwoWayCacheMemory.vue
@@ -127,7 +127,6 @@ export default {
             var cacheAddress = address & ((1 << this.cacheAddressBits) - 1);
             var cacheBlock = cacheAddress >> 2;
             var cacheTag = address >> this.cacheAddressBits;
-            console.log(cacheAddress, cacheBlock, cacheTag);
 
             // Check in cache
             for (var i = 0; i < this.cacheData.length; i++) {

--- a/src/components/model/CacheModel.vue
+++ b/src/components/model/CacheModel.vue
@@ -12,14 +12,13 @@
         </tr>
         <tr v-for="n in data.length" :key="n">
             <td class="address" :style="highlightId == (n - 1) ? rowStyle : ''">
-                <span>{{ FormatAddressHex(n - 1) }}</span>
-                <span>{{ FormatAddressBin(n - 1) }}</span>
+                <span class="hex">{{ FormatAddressHex((n - 1) * 4) }}</span>
+                <span class="bin"> ({{ FormatAddressBin((n - 1) * 4) }})</span>
             </td>
             <td :class="'valid ' + HighlightInvalid(data[n - 1].valid)" :style="highlightId == (n - 1) ? rowStyle : ''" @dblclick="ValidDblClick(n - 1)">
                 {{ data[n - 1].valid ? "T" : "F" }}
             </td>
             <td class="tag" :style="highlightId == (n - 1) ? rowStyle : ''">
-                <span>{{ FormatAddressHex(data[n - 1].tag, tagLength) }}</span>
                 <span>{{ FormatAddressBin(data[n - 1].tag, tagLength) }}</span>
             </td>
             <td class="value" :style="highlightId == (n - 1) ? rowStyle : ''">
@@ -51,6 +50,12 @@ export default {
         }
     },
 
+    computed: {
+        dataLength() {
+            return this.data.length * 4;
+        }
+    },
+
     created() {
         this.$emit("RegisterCache", { highlight: this.HighlightRow }, this.id);
     },
@@ -60,7 +65,7 @@ export default {
             // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             var bitCount;
             if (typeof tagLength == "undefined") {
-                bitCount = Math.log2(this.data.length) / 4;
+                bitCount = Math.log2(this.dataLength) / 4;
             }
             else {
                 bitCount = tagLength / 4;
@@ -79,7 +84,7 @@ export default {
             // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             var bitCount;
             if (typeof tagLength == "undefined") {
-                bitCount = Math.log2(this.data.length);
+                bitCount = Math.log2(this.dataLength);
             }
             else {
                 bitCount = tagLength;
@@ -92,7 +97,7 @@ export default {
                 bitCount = Math.floor(bitCount) + 1;
             }
 
-            return ` (${address.toString(2).padStart(bitCount, '0')})`;
+            return `${address.toString(2).padStart(bitCount, '0')}`;
         },
 
         HighlightInvalid(valid) {
@@ -110,7 +115,7 @@ export default {
         HighlightRow(id, fadeTime) {
             this.ResetIntervals();
             this.ResetHighlight();
-            this.highlightId = id;
+            this.highlightId = Math.floor(id / 4);
 
             var i = fadeTime;
             var fadeHex;
@@ -183,16 +188,13 @@ export default {
 }
 
 .cache td.address {
-    width: fit-content;
-    min-width: 5rem;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    padding: 0.1rem 0.3rem;
     text-align: right;
     font-family: Consolas, Courier, monospace;
     color: var(--fontColorFaded);
 }
 .cache td.valid {
-    width: 2.5rem;
+    width: 2rem;
     text-align: center;
     user-select: none;
 }
@@ -204,15 +206,15 @@ export default {
     cursor: pointer;
 }
 .cache td.tag {
-    width: fit-content;
-    min-width: 5rem;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    padding: 0.1rem 0.4rem;
     font-family: Consolas, Courier, monospace;
     text-align: center;
 }
 .cache td.value {
-    width: 5rem;
-    padding-left: 0.5rem;
+    padding: 0.1rem 0.4rem;
+    text-align: center;
+}
+.cache .bin {
+    font-size: 0.8rem;
 }
 </style>

--- a/src/components/model/CacheModel.vue
+++ b/src/components/model/CacheModel.vue
@@ -57,6 +57,7 @@ export default {
 
     methods: {
         FormatAddressHex(address, tagLength) {
+            // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             var bitCount;
             if (typeof tagLength == "undefined") {
                 bitCount = Math.log2(this.data.length) / 4;
@@ -75,6 +76,7 @@ export default {
             return `0x${address.toString(16).padStart(bitCount, '0').toUpperCase()}`;
         },
         FormatAddressBin(address, tagLength) {
+            // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             var bitCount;
             if (typeof tagLength == "undefined") {
                 bitCount = Math.log2(this.data.length);

--- a/src/components/model/ProcessorModel.vue
+++ b/src/components/model/ProcessorModel.vue
@@ -28,6 +28,7 @@ export default {
     },
     computed: {
         addressPointerString() {
+            // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             return `0x${this.addressPointer.toString(16).toUpperCase()}`
         }
     }

--- a/src/components/model/RamModel.vue
+++ b/src/components/model/RamModel.vue
@@ -11,7 +11,7 @@
         <tr v-for="n in data.length" :key="n">
             <td class="address" :style="highlightId == (n - 1) ? rowStyle : ''">
                 <span class="hex">{{ FormatAddressHex((n - 1) * 4) }}</span>
-                <span class="bin">{{ FormatAddressBin((n - 1) * 4) }}</span>
+                <span class="bin"> ({{ FormatAddressBin((n - 1) * 4) }})</span>
             </td>
             <td class="value" :style="highlightId == (n - 1) ? rowStyle : ''">
                 {{ data[n - 1] }}
@@ -73,7 +73,7 @@ export default {
                 bitCount = Math.floor(bitCount) + 1;
             }
 
-            return ` (${address.toString(2).padStart(bitCount, '0')})`;
+            return `${address.toString(2).padStart(bitCount, '0')}`;
         },
 
         HighlightRow(id, fadeTime) {
@@ -149,21 +149,16 @@ export default {
 }
 
 .ram td.address {
-    width: fit-content;
-    min-width: 5rem;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    padding: 0.1rem 0.4rem;
     text-align: right;
     font-family: Consolas, Courier, monospace;
     color: var(--fontColorFaded);
 }
-.ram td.address>.bin {
-    font-size: 0.8rem;
-}
 .ram td.value {
-    width: 6rem;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    padding: 0.1rem 0.4rem;
     text-align: center;
+}
+.ram .bin {
+    font-size: 0.75rem;
 }
 </style>

--- a/src/components/model/RamModel.vue
+++ b/src/components/model/RamModel.vue
@@ -10,8 +10,8 @@
         </tr>
         <tr v-for="n in data.length" :key="n">
             <td class="address" :style="highlightId == (n - 1) ? rowStyle : ''">
-                <span>{{ FormatAddressHex(n - 1) }}</span>
-                <span>{{ FormatAddressBin(n - 1) }}</span>
+                <span class="hex">{{ FormatAddressHex((n - 1) * 4) }}</span>
+                <span class="bin">{{ FormatAddressBin((n - 1) * 4) }}</span>
             </td>
             <td class="value" :style="highlightId == (n - 1) ? rowStyle : ''">
                 {{ data[n - 1] }}
@@ -40,6 +40,12 @@ export default {
         }
     },
 
+    computed: {
+        dataLength() {
+            return this.data.length * 4;
+        }
+    },
+
     created() {
         this.$emit("RegisterRam", { highlight: this.HighlightRow });
     },
@@ -47,7 +53,7 @@ export default {
     methods: {
         FormatAddressHex(address) {
             // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
-            var bitCount = Math.log2(this.data.length) / 4;
+            var bitCount = Math.log2(this.dataLength) / 4;
             if (bitCount % 1 == 0) {
                 bitCount = Math.floor(bitCount);
             }
@@ -59,7 +65,7 @@ export default {
         },
         FormatAddressBin(address) {
             // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
-            var bitCount = Math.log2(this.data.length);
+            var bitCount = Math.log2(this.dataLength);
             if (bitCount % 1 == 0) {
                 bitCount = Math.floor(bitCount);
             }
@@ -73,7 +79,7 @@ export default {
         HighlightRow(id, fadeTime) {
             this.ResetIntervals();
             this.ResetHighlight();
-            this.highlightId = id;
+            this.highlightId = Math.floor(id / 4);
 
             var i = fadeTime;
             var fadeHex;
@@ -151,8 +157,13 @@ export default {
     font-family: Consolas, Courier, monospace;
     color: var(--fontColorFaded);
 }
+.ram td.address>.bin {
+    font-size: 0.8rem;
+}
 .ram td.value {
-    width: 5rem;
+    width: 6rem;
+    padding-right: 0.5rem;
     padding-left: 0.5rem;
+    text-align: center;
 }
 </style>

--- a/src/components/model/RamModel.vue
+++ b/src/components/model/RamModel.vue
@@ -46,6 +46,7 @@ export default {
 
     methods: {
         FormatAddressHex(address) {
+            // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             var bitCount = Math.log2(this.data.length) / 4;
             if (bitCount % 1 == 0) {
                 bitCount = Math.floor(bitCount);
@@ -57,6 +58,7 @@ export default {
             return `0x${address.toString(16).padStart(bitCount, '0').toUpperCase()}`;
         },
         FormatAddressBin(address) {
+            // Source: https://stackoverflow.com/questions/42368797/how-can-i-convert-an-integer-to-hex-with-a-fix-length-in-javascript
             var bitCount = Math.log2(this.data.length);
             if (bitCount % 1 == 0) {
                 bitCount = Math.floor(bitCount);

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const app = createApp(App);
 
 // Globals
 // Animations
-app.config.globalProperties.instructionWaitTime = { value: 1000 };
+app.config.globalProperties.instructionWaitTime = { value: 500 };
 app.config.globalProperties.connectorFillTime = { value: 500 };
 app.config.globalProperties.connectorFadeTime = { value: 1000 };
 app.config.globalProperties.highlightFadeTime = { value: 1000 };

--- a/src/scripts/CacheBlock.js
+++ b/src/scripts/CacheBlock.js
@@ -4,14 +4,20 @@ export default class CacheBlock {
     constructor() {
         this.valid = true;
         this.tag = 0;
-        this.data = 0;
+        this.data = [0, 0, 0, 0];
         this.isEmpty = true;
     }
 
-    update(valid, tag, data) {
+    update(valid, tag, data, offset) {
         this.valid = valid;
         this.tag = tag;
-        this.data = data;
+
+        if (typeof offset == "undefined") {
+            this.data = [...data];
+        }
+        else {
+            this.data[offset] = data;
+        }
 
         if (this.isEmpty) {
             this.isEmpty = false;

--- a/src/scripts/Compiler.js
+++ b/src/scripts/Compiler.js
@@ -176,6 +176,7 @@ function isAddress(str) {
 // Check if string is instruction keyword
 function isKeyword(str) {
     var result = false;
+    // Source: https://www.sohamkamani.com/javascript/enums/
     Object.keys(Instruction).forEach(instruction => {
         if (instruction === str.toUpperCase()) result = true;
     });

--- a/src/scripts/Compiler.js
+++ b/src/scripts/Compiler.js
@@ -192,5 +192,5 @@ function isDecNumber(str) {
 // Check if string is hexadecimal number
 // Source: https://stackoverflow.com/questions/9221362/regular-expression-for-a-hexadecimal-number
 function isHexNumber(str) {
-    return /[0-9a-f]+/i.test(str);
+    return /[0-9a-f]+$/i.test(str);
 }

--- a/src/scripts/Compiler.js
+++ b/src/scripts/Compiler.js
@@ -133,7 +133,7 @@ function processParameterlessInstruction(instruction, instructionList) {
 function processAddressInstrution(instruction, parameter, instructionList) {
     // Check if address
     if (isAddress(parameter)) {
-        parameter = parseInt(parameter.substring(1));
+        parameter = parseInt(parameter.substring(1), 16);
         instructionList.push({ instruction: instruction, address: parameter, line: instructionLine });
     }
     else
@@ -144,7 +144,7 @@ function processAddressInstrution(instruction, parameter, instructionList) {
 // Returns result object
 function processValueInstruction(instruction, parameter, instructionList) {
     // Check if value
-    if (isNumber(parameter)) {
+    if (isDecNumber(parameter)) {
         parameter = parseInt(parameter);
         instructionList.push({ instruction: instruction, value: parameter, line: instructionLine });
     }
@@ -168,7 +168,7 @@ function isAddress(str) {
     var result = str.startsWith("@");
     if (result) {
         str = str.substring(1);
-        result = isNumber(str);
+        result = isHexNumber(str);
     }
     return result
 }
@@ -183,8 +183,14 @@ function isKeyword(str) {
     return result;
 }
 
-// Check is string is number
+// Check if string is decimal number
 // Source: https://stackoverflow.com/questions/1779013/check-if-string-contains-only-digits
-function isNumber(str) {
+function isDecNumber(str) {
     return /^-?\d+$/.test(str);
+}
+
+// Check if string is hexadecimal number
+// Source: https://stackoverflow.com/questions/9221362/regular-expression-for-a-hexadecimal-number
+function isHexNumber(str) {
+    return /[0-9a-f]+/i.test(str);
 }

--- a/src/scripts/Compiler.js
+++ b/src/scripts/Compiler.js
@@ -113,6 +113,10 @@ function processInstruction(codeList, instructionList) {
             processAddressInstrution(Instruction.IJUMP.name, codeList.shift(), instructionList);
             break;
 
+        case Instruction.FLUSH.name:
+            processParameterlessInstruction(Instruction.FLUSH.name, instructionList);
+            break;
+
         // Skip empty strings
         case "":
             break;

--- a/src/scripts/Cpu.js
+++ b/src/scripts/Cpu.js
@@ -93,6 +93,10 @@ export default class Cpu {
                 result = this._executeLabel();
                 break;
 
+            case Instruction.FLUSH.name:
+                result = this._executeFlush();
+                break;
+
             // Special program end instruction
             case "END":
                 result = this._endExecution();
@@ -251,6 +255,13 @@ export default class Cpu {
 
     // Execute LABEL instruction
     _executeLabel() {
+        return { result: ExecutionResult.NextInstruction };
+    }
+
+    // Execute FLUSH instruction
+    _executeFlush() {
+        this.cycleCounter.value = 0;
+        this.memory.flush();
         return { result: ExecutionResult.NextInstruction };
     }
 

--- a/src/scripts/enums/Instruction.js
+++ b/src/scripts/enums/Instruction.js
@@ -21,6 +21,7 @@ export default class Instruction {
     static MADD = new Instruction("MADD");
     static IJUMP = new Instruction("IJUMP");
     static LABEL = new Instruction("LABEL");
+    static FLUSH = new Instruction("FLUSH");
 
     constructor (name) {
         this.name = name

--- a/tests/unit/Compiler.spec.js
+++ b/tests/unit/Compiler.spec.js
@@ -40,12 +40,12 @@ describe("Compilers tests", () => {
     })
 
     test("Compile multiple address instructions", () => {
-        var code = "DSTORE @1 DLOAD @10 MADD @0004";
+        var code = "DSTORE @1 DLOAD @A MADD @0B1";
         var instructionList = [];
 
         startCompilation(code, instructionList);
 
-        expect(instructionList).toEqual([{ instruction: "DSTORE", address: 1, line: 1 }, { instruction: "DLOAD", address: 10, line: 1 }, { instruction: "MADD", address: 4, line: 1 }, { instruction: "END" }]);
+        expect(instructionList).toEqual([{ instruction: "DSTORE", address: 1, line: 1 }, { instruction: "DLOAD", address: 10, line: 1 }, { instruction: "MADD", address: 177, line: 1 }, { instruction: "END" }]);
     })
 
     test("Compile single label instruction", () => {
@@ -90,7 +90,7 @@ describe("Compilers tests", () => {
 
         startCompilation(code, instructionList);
 
-        expect(instructionList).toEqual([{ instruction: "MLOAD", value: 5, line: 1 }, { instruction: "LABEL", label: "loop", line: 1 }, { instruction: "DSTORE", address: 10, line: 1 }, { instruction: "ACCDEC", line: 1 }, { instruction: "ISTORE", address: 10, line: 1 }, { instruction: "BRPOS", label: "loop", line: 1 }, { instruction: "END" }]);
+        expect(instructionList).toEqual([{ instruction: "MLOAD", value: 5, line: 1 }, { instruction: "LABEL", label: "loop", line: 1 }, { instruction: "DSTORE", address: 16, line: 1 }, { instruction: "ACCDEC", line: 1 }, { instruction: "ISTORE", address: 16, line: 1 }, { instruction: "BRPOS", label: "loop", line: 1 }, { instruction: "END" }]);
     })
 
     test("Compile multiple various instructions with line breaks", () => {
@@ -99,7 +99,7 @@ describe("Compilers tests", () => {
 
         startCompilation(code, instructionList);
 
-        expect(instructionList).toEqual([{ instruction: "MLOAD", value: 5, line: 1 }, { instruction: "LABEL", label: "loop", line: 2 }, { instruction: "DSTORE", address: 10, line: 3 }, { instruction: "ACCDEC", line: 4 }, { instruction: "ISTORE", address: 10, line: 5 }, { instruction: "BRPOS", label: "loop", line: 6 }, { instruction: "END" }]);
+        expect(instructionList).toEqual([{ instruction: "MLOAD", value: 5, line: 1 }, { instruction: "LABEL", label: "loop", line: 2 }, { instruction: "DSTORE", address: 16, line: 3 }, { instruction: "ACCDEC", line: 4 }, { instruction: "ISTORE", address: 16, line: 5 }, { instruction: "BRPOS", label: "loop", line: 6 }, { instruction: "END" }]);
     })
 
     test("Compile code with comments", () => {
@@ -126,7 +126,7 @@ describe("Compilers tests", () => {
     })
 
     test("Fail at invalid address parameter, not a number", () => {
-        var code = "NOP DSTORE @1a NOP";
+        var code = "NOP DSTORE @1gh NOP";
         var instructionList = [];
 
         expect(() => startCompilation(code, instructionList)).toThrow();

--- a/tests/unit/Cpu.spec.js
+++ b/tests/unit/Cpu.spec.js
@@ -488,7 +488,7 @@ describe("CPU instruction error tests", () => {
         // Prepare
         var acc = { value: 0 };
         var ap = { value: 0 };
-        var instructionList = [{ instruction: "DLOAD", address: 32 }, { instruction: "END" }];
+        var instructionList = [{ instruction: "DLOAD", address: 256 }, { instruction: "END" }];
 
         const wrapper = mount(RamOnlyMemory);
         var memory = wrapper.emitted().RegisterMemory[0][0];
@@ -516,7 +516,7 @@ describe("CPU instruction error tests", () => {
         // Prepare
         var acc = { value: 10 };
         var ap = { value: 0 };
-        var instructionList = [{ instruction: "DSTORE", address: 32 }, { instruction: "END" }];
+        var instructionList = [{ instruction: "DSTORE", address: 256 }, { instruction: "END" }];
 
         const wrapper = mount(RamOnlyMemory);
         var memory = wrapper.emitted().RegisterMemory[0][0];


### PR DESCRIPTION
Zjistil jsem, že mít jen jednu hodnotu v každém paměťovém bloku neumožní dostatečně prezentovat paměťově nevhodné algoritmus. Kvůli tomu byl obsah paměťových bloků předělán tak, aby obsahoval 4 hodnoty.

Pro zjednodušení adresování do paměti se adresové parametry budou zapisovat jako hexadecimální číslo (např. `@A1`).

Také byly opraveny některé chyby vyskytující se při práci s pamětí jiné velikosti než je výchozí.